### PR TITLE
Fix toast listener leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -184,7 +184,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix listener registration in `useToast` so multiple listeners aren't added each render

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*