### PR TITLE
Add API docs and key management

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,28 @@
+# API Security Audit
+
+This document summarizes a quick audit of all Next.js API routes under `src/app/api`.
+
+## Authentication checks
+
+Most routes use the `withAuth` helper which validates a JWT from the `Authorization` header. Admin-only endpoints call `withAuth` with the `adminOnly` flag enabled. The following routes do **not** use `withAuth`:
+
+- `api/step_types` – returns public information about available step types.
+- `api/auth/session` – issues JWT tokens and must remain public.
+- `api/sign` – signs payloads using a server key and currently has **no authentication**.
+- `api/webhooks/stripe` – Stripe webhooks require no authentication but verify a Stripe signature.
+
+The `/api/sign` endpoint exposes signing capabilities without any permission checks. If exposed publicly it could be abused to generate arbitrary signatures. Restricting this route or requiring authentication is recommended.
+
+## Authorization logic
+
+Admin routes use the `adminOnly` option in `withAuth` ensuring the `adm` claim is present in the token. User routes verify that the requested resource belongs to the user’s community. Example: `api/user/wizards/[id]/steps` checks that the wizard’s `community_id` matches the token’s community ID.
+
+No other missing permission checks were found during this cursory review.
+
+## Other considerations
+
+- Rate limiting is applied to some endpoints via the quota utilities but not all. Consider adding generic rate limiting middleware.
+- Input validation is handled with `zod` in many endpoints. Ensure all user‑supplied parameters are validated to avoid SQL injection or crashes.
+- Sensitive operations such as Stripe webhooks use secrets from environment variables and verify incoming signatures.
+
+Overall the API implements authentication consistently. The main issue discovered is the unauthenticated `/api/sign` route which should be restricted or removed in production.

--- a/migrations/20240520000000_create_api_keys_table.js
+++ b/migrations/20240520000000_create_api_keys_table.js
@@ -1,0 +1,15 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable('community_api_keys', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    community_id: { type: 'text', notNull: true, references: 'communities', onDelete: 'CASCADE' },
+    token_hash: { type: 'text', notNull: true, unique: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
+  });
+  pgm.createIndex('community_api_keys', 'community_id');
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('community_api_keys');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@radix-ui/react-slot": "^1.2.1",
         "@radix-ui/react-switch": "^1.2.2",
         "@radix-ui/react-tabs": "^1.1.9",
+        "swagger-ui-react": "^5.13.0",
         "@radix-ui/react-toast": "^1.2.11",
         "@radix-ui/react-tooltip": "^1.2.4",
         "@rainbow-me/rainbowkit": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-slot": "^1.2.1",
     "@radix-ui/react-switch": "^1.2.2",
     "@radix-ui/react-tabs": "^1.1.9",
+    "swagger-ui-react": "^5.13.0",
     "@radix-ui/react-toast": "^1.2.11",
     "@radix-ui/react-tooltip": "^1.2.4",
     "@rainbow-me/rainbowkit": "^2.2.4",

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "CG Sample Plugin API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/auth/session": {
+      "post": {
+        "summary": "Create a JWT session",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "iframeUid": { "type": "string" },
+                  "userId": { "type": "string" },
+                  "communityId": { "type": "string" },
+                  "isAdmin": { "type": "boolean" }
+                },
+                "required": ["iframeUid", "userId", "communityId", "isAdmin"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "JWT issued" }
+        }
+      }
+    },
+    "/api/step_types": {
+      "get": {
+        "summary": "List available step types",
+        "responses": { "200": { "description": "Array of step types" } }
+      }
+    },
+    "/api/admin/api-keys": {
+      "get": {
+        "summary": "List API keys for the current community",
+        "responses": { "200": { "description": "Array of keys" } }
+      },
+      "post": {
+        "summary": "Create a new API key",
+        "responses": { "201": { "description": "Key created" } }
+      }
+    },
+    "/api/admin/api-keys/{id}": {
+      "delete": {
+        "summary": "Delete an API key",
+        "parameters": [{
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }],
+        "responses": { "200": { "description": "Key deleted" } }
+      }
+    }
+  }
+}

--- a/src/app/PluginContainer.tsx
+++ b/src/app/PluginContainer.tsx
@@ -20,7 +20,8 @@ import { WizardView } from '../components/WizardView';
 import { ContactView } from '../components/ContactView';
 import { DebugSettingsView } from '../components/DebugSettingsView';
 import { SuperAdminDashboardView } from '../components/super-admin/SuperAdminDashboardView';
-import { LayoutDashboard, Settings, Plug, User, Wand2, Loader2, Terminal, ShieldAlert } from 'lucide-react';
+import { LayoutDashboard, Settings, Plug, User, Wand2, Loader2, Terminal, ShieldAlert, FileCode2 } from 'lucide-react';
+import ApiDocsView from '../components/ApiDocsView';
 import { Toaster } from "@/components/ui/toaster";
 import { useWizardSlideshow } from '../context/WizardSlideshowContext';
 import { WizardSlideshowModal } from '../components/onboarding/WizardSlideshowModal';
@@ -42,6 +43,7 @@ const adminLinks = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { id: 'config', label: 'Wizard Config', icon: Settings },
   { id: 'connections', label: 'Connections', icon: Plug },
+  { id: 'api-docs', label: 'API Docs', icon: FileCode2 },
   // { id: 'account', label: 'Account', icon: Building }, // Removed Account link
   // { id: 'debug', label: 'Debug Settings', icon: Terminal }, // Already removed and handled separately
 ];
@@ -429,9 +431,11 @@ const AppCore: React.FC<AppCoreProps> = (props) => {
       case 'help': 
         // Pass isAdmin as a strict boolean
         return <HelpView isAdmin={isAdmin === true && !isPreviewingAsUser} />;
-      case 'contact': 
+      case 'contact':
         return <ContactView />;
-      default: 
+      case 'api-docs':
+        return <ApiDocsView />;
+      default:
         return <div className="p-4">Unknown Section: {activeSection}</div>;
     }
   };

--- a/src/app/api/admin/api-keys/[id]/route.ts
+++ b/src/app/api/admin/api-keys/[id]/route.ts
@@ -1,0 +1,19 @@
+import { withAuth, AuthenticatedRequest } from '@/lib/withAuth';
+import { NextResponse } from 'next/server';
+import { deleteApiKey } from '@/lib/services/apiKeyService';
+
+interface Params { id: string }
+
+export const DELETE = withAuth<Params>(async (req: AuthenticatedRequest, { params }) => {
+  const user = req.user;
+  if (!user?.cid) {
+    return NextResponse.json({ error: 'Community ID missing' }, { status: 400 });
+  }
+  try {
+    await deleteApiKey(params.id, user.cid);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Error deleting API key:', err);
+    return NextResponse.json({ error: 'Failed to delete API key' }, { status: 500 });
+  }
+}, true);

--- a/src/app/api/admin/api-keys/route.ts
+++ b/src/app/api/admin/api-keys/route.ts
@@ -1,0 +1,31 @@
+import { withAuth, AuthenticatedRequest } from '@/lib/withAuth';
+import { NextResponse } from 'next/server';
+import { createApiKey, listApiKeys } from '@/lib/services/apiKeyService';
+
+export const POST = withAuth(async (req: AuthenticatedRequest) => {
+  const user = req.user;
+  if (!user?.cid) {
+    return NextResponse.json({ error: 'Community ID missing' }, { status: 400 });
+  }
+  try {
+    const result = await createApiKey(user.cid);
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    console.error('Error creating API key:', err);
+    return NextResponse.json({ error: 'Failed to create API key' }, { status: 500 });
+  }
+}, true);
+
+export const GET = withAuth(async (req: AuthenticatedRequest) => {
+  const user = req.user;
+  if (!user?.cid) {
+    return NextResponse.json({ error: 'Community ID missing' }, { status: 400 });
+  }
+  try {
+    const keys = await listApiKeys(user.cid);
+    return NextResponse.json({ keys });
+  } catch (err) {
+    console.error('Error listing API keys:', err);
+    return NextResponse.json({ error: 'Failed to list API keys' }, { status: 500 });
+  }
+}, true);

--- a/src/components/ApiDocsView.tsx
+++ b/src/components/ApiDocsView.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import React from 'react';
+import SwaggerUI from 'swagger-ui-react';
+import 'swagger-ui-react/swagger-ui.css';
+
+export const ApiDocsView: React.FC = () => (
+  <div className="flex-1 overflow-auto p-4">
+    <SwaggerUI url="/swagger.json" />
+  </div>
+);
+
+export default ApiDocsView;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Image from 'next/image'; // Re-add Image import
 import { Button } from "@/components/ui/button";
-import { BookOpen, Eye, Undo, Mail, SparklesIcon } from 'lucide-react'; // Removed Loader2 import
+import { BookOpen, Eye, Undo, Mail, SparklesIcon, FileCode2 } from 'lucide-react'; // Removed Loader2 import
 // import { useQuery } from '@tanstack/react-query'; // Removed
 import { SidebarUserProfile } from './SidebarUserProfile';
 import { useAdminAIChatModalStore } from '@/stores/useAdminAIChatModalStore'; // Added store import
@@ -167,13 +167,21 @@ export const Sidebar: React.FC<SidebarProps> = ({
       <div className="py-2 px-3 border-t border-border">
         <p className="text-xs font-medium text-muted-foreground px-2 mb-2">SUPPORT</p>
         <div className="space-y-1.5">
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             className="w-full justify-start text-muted-foreground hover:text-foreground transition-all duration-200 hover:bg-secondary/40"
             onClick={() => setActiveSection('help')}
           >
             <BookOpen className="w-4 h-4 mr-2" />
             Help & Documentation
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full justify-start text-muted-foreground hover:text-foreground transition-all duration-200 hover:bg-secondary/40"
+            onClick={() => setActiveSection('api-docs')}
+          >
+            <FileCode2 className="w-4 h-4 mr-2" />
+            API Docs
           </Button>
           {/* Render Debug Settings Link if provided - MOVED HERE */}
           {debugLink && (

--- a/src/lib/services/apiKeyService.ts
+++ b/src/lib/services/apiKeyService.ts
@@ -1,0 +1,42 @@
+import { query } from '@/lib/db';
+import crypto from 'crypto';
+
+export interface ApiKey {
+  id: string;
+  community_id: string;
+  token_hash: string;
+  created_at: string;
+}
+
+export async function createApiKey(communityId: string): Promise<{ id: string; token: string }> {
+  const token = crypto.randomBytes(32).toString('hex');
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+  const result = await query<ApiKey>(
+    `INSERT INTO community_api_keys (community_id, token_hash)
+     VALUES ($1, $2)
+     RETURNING id, community_id, token_hash, created_at`,
+    [communityId, tokenHash]
+  );
+
+  if (result.rows.length === 0) {
+    throw new Error('Failed to create API key');
+  }
+
+  return { id: result.rows[0].id, token };
+}
+
+export async function listApiKeys(communityId: string): Promise<ApiKey[]> {
+  const result = await query<ApiKey>(
+    `SELECT id, community_id, token_hash, created_at
+       FROM community_api_keys
+      WHERE community_id = $1
+      ORDER BY created_at DESC`,
+    [communityId]
+  );
+  return result.rows;
+}
+
+export async function deleteApiKey(id: string, communityId: string): Promise<void> {
+  await query(`DELETE FROM community_api_keys WHERE id = $1 AND community_id = $2`, [id, communityId]);
+}


### PR DESCRIPTION
## Summary
- write a security audit of API endpoints
- serve a Swagger spec and viewer
- link API docs from sidebar
- add admin API key management endpoints
- store API keys in database

## Testing
- `npm run lint`